### PR TITLE
Add compatibility table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ HPE FlexibleLOM to PCIe adapter
 ===============================
 
 This PCB is an adapter that allows using HPE FlexibleLOM cards in normal
-PCIe x8 slots.
+PCIe x8 slots. The [table at the bottom of this README](README.md#compatibility-table)
+lists cards that have been reported by the community to be compatible.
 
 ![PCB top](/assets/revA_photo_top.jpg)
 
@@ -62,3 +63,23 @@ can try setting this jumper to 4x if you are having issues with card detection.
 However, a lot of modern devices tend to ignore the PRSNT2 line and rely solely on
 detecting the lane transmitters/receivers. Thus this setting will be irrelevant for
 most devices.
+
+
+# Compatibility table
+
+This table indicates which HPE FlexibleLOM cards have been reported by the
+community to be compatible with the adapter. Note that the adapter is available
+in multiple revisions (see
+[here](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/tree/revc-experimental/gerbers)
+for Gerber files). Make sure to order / build the correct revision of the adapter
+for your card!
+
+| Card             | Adapter revision | References
+|------------------|------------------|-------------------------
+| 331FLR           | C                | [1](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-811085800) |
+| 530FLR-SFP+      | C; [B with modifications](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-813043358) | [1](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-811085800), [2](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-813043358), [3](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-885123900) |
+| 533FLR-T         | [B with modifications](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-820209341) | [1](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-820209341), [2](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-885123900) |
+| 544+FLR          | A                | [1](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/9#issue-1166787439) |
+| 544+FLR-QSFP     | B                | [1](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-803328085) |
+| 560FLR-SFP+      | C                | [1](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/4#issuecomment-811085800) |
+| 561FLR-T         | A                | [1](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/3), [2](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/3#issue-765534761), [3](https://github.com/TobleMiner/HPE-FlexibleLOM-adapter/issues/3#issuecomment-813351510) |


### PR DESCRIPTION
The table summarizes the various compatibility reports from the https://github.com/TobleMiner/HPE-FlexibleLOM-adapter issue tracker. It lists the card, adapter revision, and reference link(s) for each compatibility report. Modifications are noted and hyperlinked as mentioned in the issue threads.

The intro to the table also points out the existence of adapter revisions, and the community-sourced nature of compatibility reports.

Hat tip to @KCORES and their https://github.com/KCORES/KCORES-FlexibleLOM-Adapter with an even more featureful compat table